### PR TITLE
Add unit tests for UserRepository and UserVm

### DIFF
--- a/test/features/user/data/user_repository_test.dart
+++ b/test/features/user/data/user_repository_test.dart
@@ -1,0 +1,29 @@
+import 'package:dio/src/cancel_token.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netlab/features/user/data/user_data_source.dart';
+import 'package:netlab/features/user/data/user_dto.dart';
+import 'package:netlab/features/user/data/user_repository.dart';
+
+class _DsFake implements UserDataSource {
+  @override
+  Future<UserDto> fetchUser(int id, {CancelToken? cancelToken}) async =>
+      const UserDto(id: 1, name: 'T', username: 't', email: 't@e');
+}
+
+void main() {
+  test('Repository uses DataSource and returns DTO', () async {
+    final c = ProviderContainer(
+      overrides: [
+        userRepositoryProvider.overrideWith(
+          (_) => UserRepositoryImpl(_DsFake()),
+        ),
+      ],
+    );
+    addTearDown(c.dispose);
+
+    final repo = c.read(userRepositoryProvider);
+    final u = await repo.getUser(1);
+    expect(u.username, 't');
+  });
+}

--- a/test/features/user/presentation/user_vm_test.dart
+++ b/test/features/user/presentation/user_vm_test.dart
@@ -1,4 +1,4 @@
-import 'package:dio/src/cancel_token.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:netlab/features/user/data/user_dto.dart';
@@ -11,6 +11,22 @@ class _RepoFake implements UserRepository {
       const UserDto(id: 1, name: 'test', username: 'test', email: 't@e');
 }
 
+class _RepoError implements UserRepository {
+  @override
+  Future<UserDto> getUser(int id, {CancelToken? cancel}) async {
+    throw Exception('boom');
+  }
+}
+
+class _RepoCounting implements UserRepository {
+  int n = 0;
+  @override
+  Future<UserDto> getUser(int id, {cancel}) async {
+    n++;
+    return UserDto(id: 1, name: 'N$n', username: 'u', email: 'e');
+  }
+}
+
 void main() {
   test('UserVm loads', () async {
     final c = ProviderContainer(
@@ -19,6 +35,30 @@ void main() {
     addTearDown(c.dispose);
 
     final text = await c.read(userVmProvider.future);
-    expect(text, contains('Test'));
+    expect(text, contains('test')); // name (lowercase as provided by _RepoFake)
+    expect(text, contains('t@e')); // email
+  });
+
+  test('UserVm error -> AsyncError', () async {
+    final c = ProviderContainer(
+      overrides: [userRepositoryProvider.overrideWith((_) => _RepoError())],
+    );
+    addTearDown(c.dispose);
+
+    await expectLater(c.read(userVmProvider.future), throwsA(isA<Exception>()));
+    expect(c.read(userVmProvider).hasError, true);
+  });
+
+  test('refresh updates text', () async {
+    final c = ProviderContainer(
+      overrides: [userRepositoryProvider.overrideWith((_) => _RepoCounting())],
+    );
+    addTearDown(c.dispose);
+
+    final first = await c.read(userVmProvider.future);
+    await c.read(userVmProvider.notifier).refresh();
+    final second = await c.read(userVmProvider.future);
+
+    expect(first, isNot(equals(second)));
   });
 }


### PR DESCRIPTION
# Description
この PR では、ユーザーデータ取得処理に関するユニットテストを追加しました。  
前回の PR で基盤部分を整備したため、今回は以下 2 ファイルに限定しています。

## 変更内容
- **user_repository_test.dart**
  - `UserRepositoryImpl` が `UserDataSource` を利用し、期待通りの `UserDto` を返すことを確認するテストを追加。

- **user_vm_test.dart**
  - `UserVm` がリポジトリから取得したユーザーデータを正しく文字列に変換することを確認。
  - リポジトリが例外を投げた場合に `AsyncError` が発生することを確認。
  - `refresh` 実行時にデータが更新されることを確認。

## 確認方法
1. 以下を実行  
   ```bash
   flutter test
   ```