### PR TITLE
UserRepositoryをFake/Remote切替可能にする

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+part 'app_config.g.dart';
+
 @riverpod
 bool useFake(Ref ref) =>
     const bool.fromEnvironment('USE_FAKE', defaultValue: true);

--- a/lib/core/config/app_config.g.dart
+++ b/lib/core/config/app_config.g.dart
@@ -1,27 +1,27 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'user_repository.dart';
+part of 'app_config.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$userRepositoryHash() => r'fbc72afb8fcbf78722bb821bb596b84caf6cb49e';
+String _$useFakeHash() => r'e0f4dcbf9ff53e385d36eb9822ae39220e3e8b4e';
 
-/// See also [userRepository].
-@ProviderFor(userRepository)
-final userRepositoryProvider = AutoDisposeProvider<UserRepository>.internal(
-  userRepository,
-  name: r'userRepositoryProvider',
+/// See also [useFake].
+@ProviderFor(useFake)
+final useFakeProvider = AutoDisposeProvider<bool>.internal(
+  useFake,
+  name: r'useFakeProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$userRepositoryHash,
+      : _$useFakeHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef UserRepositoryRef = AutoDisposeProviderRef<UserRepository>;
+typedef UseFakeRef = AutoDisposeProviderRef<bool>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/user/data/remote_user_data_source.dart
+++ b/lib/features/user/data/remote_user_data_source.dart
@@ -1,0 +1,15 @@
+import 'package:dio/dio.dart';
+import 'package:netlab/core/network/api_client.dart';
+import 'package:netlab/features/user/data/user_data_source.dart';
+import 'package:netlab/features/user/data/user_dto.dart';
+
+class RemoteUserDataSource implements UserDataSource {
+  final ApiClient _api;
+  RemoteUserDataSource(this._api);
+
+  @override
+  Future<UserDto> fetchUser(int id, {CancelToken? cancelToken}) async {
+    final r = await _api.get<Map<String, dynamic>>('/users/$id');
+    return UserDto.fromJson(r.data!);
+  }
+}

--- a/lib/features/user/data/user_repository.dart
+++ b/lib/features/user/data/user_repository.dart
@@ -1,6 +1,10 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:netlab/core/config/app_config.dart';
+import 'package:netlab/core/network/api_client.dart';
+import 'package:netlab/core/network/dio_provider.dart';
 import 'package:netlab/features/user/data/fake_user_data_source.dart';
+import 'package:netlab/features/user/data/remote_user_data_source.dart';
 import 'package:netlab/features/user/data/user_data_source.dart';
 import 'package:netlab/features/user/data/user_dto.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -23,6 +27,11 @@ class UserRepositoryImpl implements UserRepository {
 
 @riverpod
 UserRepository userRepository(Ref ref) {
-  // まずは Fake だけで起動確認（Remoteは次PRで差し替える）
-  return UserRepositoryImpl(FakeUserDataSource());
+  final isFake = ref.watch(useFakeProvider);
+  if (isFake) {
+    return UserRepositoryImpl(FakeUserDataSource());
+  }
+  final dio = ref.watch(dioProvider);
+  final api = ApiClient(dio);
+  return UserRepositoryImpl(RemoteUserDataSource(api));
 }

--- a/test/features/user/data/user_repository_test.dart
+++ b/test/features/user/data/user_repository_test.dart
@@ -22,7 +22,7 @@ void main() {
     );
     addTearDown(c.dispose);
 
-    final repo = c.read(userRepositoryProvider);
+    final repo = c.read(userRepository);
     final u = await repo.getUser(1);
     expect(u.username, 't');
   });


### PR DESCRIPTION
## 概要
- `useFake` フラグを導入し、`dart-define` で Fake / Remote を切り替え可能にしました。
- `UserRepository` がフラグに応じて `FakeUserDataSource` または `RemoteUserDataSource` を利用するように変更しました。
- Remote 実装では `ApiClient` 経由で `/users/{id}` を取得し、`UserDto` に変換します。

## 変更内容
- `lib/core/config/app_config.dart`
  - `useFake` Provider を追加
- `lib/features/user/data/remote_user_data_source.dart`
  - `RemoteUserDataSource` を新規実装
- `lib/features/user/data/user_repository.dart`
  - Fake / Remote 切替処理を実装

## 動作確認方法
### Fakeモード（デフォルト）
```bash
flutter run
```
### Remoteモード
```
flutter run \
  --dart-define=USE_FAKE=false \
  --dart-define=API_BASE_URL=https://jsonplaceholder.typicode.com
```